### PR TITLE
Rollback instead of commit when encountering an SqlException

### DIFF
--- a/GalacticWasteManagement/ConnectionManager.cs
+++ b/GalacticWasteManagement/ConnectionManager.cs
@@ -52,6 +52,13 @@ namespace GalacticWasteManagement
             }
         }
 
+        public void Rollback()
+        {
+            _uow?.Rollback();
+            _uow?.Dispose();
+            _uow = null;
+        }
+
         public void Dispose()
         {
             try

--- a/GalacticWasteManagement/MigrationBase.cs
+++ b/GalacticWasteManagement/MigrationBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using GalacticWasteManagement.Logging;
@@ -202,7 +203,15 @@ SELECT NULL
             using (var connectionManager = ManageConnection())
             {
                 _connectionManager = connectionManager;
-                await ManageWaste();
+                try 
+                { 
+                    await ManageWaste();
+                }
+                catch(SqlException)
+                {
+                    _connectionManager.Rollback();
+                    throw;
+                }
             }
         }
 

--- a/GalacticWasteManagement/MigrationBase.cs
+++ b/GalacticWasteManagement/MigrationBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
@@ -207,7 +207,7 @@ SELECT NULL
                 { 
                     await ManageWaste();
                 }
-                catch(SqlException)
+                catch(Exception)
                 {
                     _connectionManager.Rollback();
                     throw;


### PR DESCRIPTION
This enables GWM to log the actual exception message and not the just the zombie transaction exception that occurs when trying to commit after failure

Fixes #50